### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN buildDeps='wget ca-certificates' \
   && echo "===> Update Sophos..." \
   && mkdir -p /opt/malice \
   && /opt/sophos/update/savupdate.sh \
+  && /opt/sophos/bin/savconfig  set DisableFeedback true \
   && echo "===> Clean up unnecessary files..." \
   && apt-get purge -y --auto-remove $buildDeps \
   && apt-get clean \


### PR DESCRIPTION
Zitat "Der Sophos Scanner spricht nach der Installation mit dem Sophos Server und übermittelt Daten (phone-home). Allerdings muss man sagen, dass Sophos so fair ist und eine ausführliche Liste bereit stellt, in der gelistet ist, was übermittelt wird. Will jemand diese Funktion abschalten, kann er das tun:

/opt/sophos-av/bin/savconfig set DisableFeedback true
or 
/opt/sophos/bin/savconfig  set DisableFeedback true
"